### PR TITLE
Add root env example and fix compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+AUTH_SECRET=met_un_vrai_secret_de_32_char
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mini_trello
+CLIENT_ORIGIN=http://localhost:5173

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       dockerfile: Dockerfile
       target: api
     env_file:
-      - ../.env
+      - ../.env.example
     ports:
       - "4000:4000"
     depends_on:
@@ -33,7 +33,7 @@ services:
       dockerfile: Dockerfile
       target: web
     env_file:
-      - ../.env
+      - ../.env.example
     ports:
       - "5173:80"
 


### PR DESCRIPTION
## Summary
- provide `.env.example` so docker-compose envs work out of the box
- update compose file to use the example file

## Testing
- `pnpm lint` *(fails: Could not find turbo.json)*
- `pnpm --filter api lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6869324f3d188327a9271a8dda73ff0a