### PR TITLE
Fix .gitignore coverage path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ node_modules/
 dist/
 build/
 .next/
-coverage/"
+coverage/
 *.tsbuildinfo
 
 # env


### PR DESCRIPTION
## Summary
- fix the coverage directory pattern in `.gitignore`

## Testing
- `pnpm lint` *(fails: could not find turbo.json)*
- `pnpm check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869324dcd6c8327943595c591dd1641